### PR TITLE
fix(Seguros): ORB-1314 - Criando arquivo separado para ENUM de updateIndex

### DIFF
--- a/swagger-components/_insurances_apis_part.yml
+++ b/swagger-components/_insurances_apis_part.yml
@@ -165,6 +165,8 @@ components:
       $ref: ./schemas/enum/EnumCoverageItemGeographicScopeType.yaml
     EnumInsurancePersonalBenefitRecalculationCriteria:
       $ref: ./schemas/enum/EnumInsurancePersonalBenefitRecalculationCriteria.yaml
+    EnumInsurancePersonalBenefitRecalculationUpdateIndex:
+      $ref: ./schemas/enum/EnumInsurancePersonalBenefitRecalculationUpdateIndex.yaml
     AutomotivePartsItem:
       $ref: ./schemas/insurances_apis/automotive/AutomotivePartsItem.yaml
     EnumAutomotivePartType:

--- a/swagger-components/schemas/enum/EnumInsurancePersonalBenefitRecalculationUpdateIndex.yaml
+++ b/swagger-components/schemas/enum/EnumInsurancePersonalBenefitRecalculationUpdateIndex.yaml
@@ -1,0 +1,14 @@
+type: string
+description: |
+  Índice utilizado na atualização da PMBaC:
+    1. IPCA (IBGE)
+    2. IGP-M (FGV)
+    3. INPC (IBGE)
+    4. NÃO APLICA
+maxLength: 10
+enum:
+  - IPCA
+  - IGP_M
+  - INPC
+  - NAO_APLICA
+example: IPCA

--- a/swagger-components/schemas/insurances_apis/InsuranceBenefitRecalculation.yaml
+++ b/swagger-components/schemas/insurances_apis/InsuranceBenefitRecalculation.yaml
@@ -10,5 +10,5 @@ properties:
   updateIndexes:
     type: array
     items:
-      $ref: ../enum/EnumPersonalUpdateIndex.yaml
+      $ref: ../enum/EnumInsurancePersonalBenefitRecalculationUpdateIndex.yaml
 additionalProperties: false


### PR DESCRIPTION
Devido o arquivo de ENUM updateIndex ser utilizar em mais de uma api, surgiu a necessidade de criar outro enum exclusivo para elemento de benefitRecalculationUpdateIndex.