### PR TITLE
  fix(Cartão de Crédito): ORB-1408 - Ajustar campos de acordo homologação

### DIFF
--- a/dictionary/creditCardsGetAccountsCreditCardAccountIdBillsBillIdTransactions_v2.csv
+++ b/dictionary/creditCardsGetAccountsCreditCardAccountIdBillsBillIdTransactions_v2.csv
@@ -48,7 +48,8 @@ Para recebedora: Ignorar o campo preenchido conforme esse cenário.
 /data/otherCreditsAdditionalInfo;otherCreditsAdditionalInfo;Campo livre para preenchimento de dados adicionais de outros tipos de crédito contratados no cartão.;Texto;50;Opcional;^\S[\s\S]*$;;0;1;" Preenchimento obrigatório quando selecionado no campo outros tipos de crédito ""OUTROS"".
 ";Não permitido;string;
 /data/chargeIdentificator;chargeIdentificator;Identificador da parcela que está sendo informada. Campo de livre preenchimento;Texto;50;Obrigatório;[\w\W\s]*;;1;1;"";Não permitido;string;PARCELA_1
-/data/chargeNumber;chargeNumber;Quantidade de parcelas;Número;;Obrigatório;;;1;1;"";Não permitido;number;3
+/data/chargeNumber;chargeNumber;Quantidade de parcelas.;Número;;Opcional;;;0;1;" O campo deve ser preenchido quando houverem parcelas relacionadas a transação.
+";Não permitido;number;12
 /data/brazilianAmount;brazilianAmount;Valor da transação expresso em valor monetário com 4 casas decimais, em moeda corrente do Brasil;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;
 /data/brazilianAmount/amount;amount;Valor relacionado ao objeto.;Texto;20;Obrigatório;^\d{1,15}\.\d{2,4}$;;1;1;"";Não permitido;string;100000.0400
 /data/brazilianAmount/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL
@@ -57,4 +58,4 @@ Para recebedora: Ignorar o campo preenchido conforme esse cenário.
 /data/amount/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL
 /data/transactionDate;transactionDate;Data original da transação;Data;20;Obrigatório;^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$;;1;1;"";Não permitido;string;2021-05-21
 /data/billPostDate;billPostDate;Data em que a transação foi inserida na fatura;Data;20;Obrigatório;^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$;;1;1;"";Não permitido;string;2021-05-21
-/data/payeeMCC;payeeMCC;O MCC ou o código da categoria do estabelecimento comercial. Os MCCs são agrupados segundo suas similaridades. O MCC é usado para classificar o negócio pelo tipo fornecido de bens ou serviços. Os MCCs são atribuídos por tipo de comerciante (por exemplo, um para hotéis, um para lojas de materiais de escritório, etc.) ou por nome de comerciante (por exemplo, 3000 para a United Airlines).;Número;;Obrigatório;;;1;1;"";Não permitido;number;5137
+/data/payeeMCC;payeeMCC;O MCC ou o código da categoria do estabelecimento comercial. Os MCCs são agrupados segundo suas similaridades. O MCC é usado para classificar o negócio pelo tipo fornecido de bens ou serviços. Os MCCs são atribuídos por tipo de comerciante (por exemplo, um para hotéis, um para lojas de materiais de escritório, etc.) ou por nome de comerciante (por exemplo, 3000 para a United Airlines).;Número;;Opcional;;;0;1;"";Não permitido;number;5137

--- a/dictionary/creditCardsGetAccountsCreditCardAccountIdLimits_v2.csv
+++ b/dictionary/creditCardsGetAccountsCreditCardAccountIdLimits_v2.csv
@@ -19,8 +19,10 @@ OUTROS";0;1;"";Não permitido;string;CREDITO_A_VISTA
 /data/lineNameAdditionalInfo;lineNameAdditionalInfo;Campo de preenchimento obrigatório se selecionada a opção 'OUTRAS' em lineName.;Texto;50;Opcional;[\w\W\s]*;;0;1;"";Não permitido;string;Informações adicionais e complementares.
 /data/isLimitFlexible;isLimitFlexible;Indica se a operação de crédito é: com limite flexível (true) ou com limite (false).;Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;true
 /data/limitAmountCurrency;limitAmountCurrency;"Moeda referente ao limite informado, segundo modelo ISO-4217. p.ex. 'BRL.'
-Todos os limite informados estão representados com a moeda vigente do do Brasil.";Texto;3;Obrigatório;^(\w{3}){1}$;;1;1;"";Não permitido;string;BRL
-/data/limitAmount;limitAmount;Valor total do limite informado Expresso em valor monetário com 4 casas decimais.;Texto;21;Obrigatório;^-?\d{1,15}\.\d{2,4}$;;1;1;"";Não permitido;string;100000.0001
+Todos os limite informados estão representados com a moeda vigente do do Brasil.";Texto;3;Opcional;^(\w{3}){1}$;;0;1;" O campo é opcional caso isLimitFlexible for igual a false.
+";Não permitido;string;BRL
+/data/limitAmount;limitAmount;Valor total do limite informado Expresso em valor monetário com 4 casas decimais.;Texto;21;Opcional;^-?\d{1,15}\.\d{2,4}$;;0;1;" O campo é opcional caso isLimitFlexible for igual a false.
+";Não permitido;string;100000.0001
 /data/usedAmountCurrency;usedAmountCurrency;"Moeda referente ao limite informado, segundo modelo ISO-4217. p.ex. 'BRL.'
 Todos os saldos informados estão representados com a moeda vigente do Brasil.";Texto;3;Obrigatório;^(\w{3}){1}$;;1;1;"";Não permitido;string;BRL
 /data/usedAmount;usedAmount;Valor utilizado do limite informado Expresso em valor monetário com 4 casas decimais.;Texto;21;Obrigatório;^-?\d{1,15}\.\d{2,4}$;;1;1;"";Não permitido;string;7500.0500

--- a/dictionary/creditCardsGetAccountsCreditCardAccountIdTransactions_v2.csv
+++ b/dictionary/creditCardsGetAccountsCreditCardAccountIdTransactions_v2.csv
@@ -48,7 +48,8 @@ Para recebedora: Ignorar o campo preenchido conforme esse cenário.
 /data/otherCreditsAdditionalInfo;otherCreditsAdditionalInfo;Campo livre para preenchimento de dados adicionais de outros tipos de crédito contratados no cartão.;Texto;50;Opcional;^\S[\s\S]*$;;0;1;" Preenchimento obrigatório quando selecionado no campo outros tipos de crédito ""OUTROS"".
 ";Não permitido;string;
 /data/chargeIdentificator;chargeIdentificator;Identificador da parcela que está sendo informada. Campo de livre preenchimento;Texto;50;Obrigatório;[\w\W\s]*;;1;1;"";Não permitido;string;PARCELA_1
-/data/chargeNumber;chargeNumber;Quantidade de parcelas;Número;;Obrigatório;;;1;1;"";Não permitido;number;3
+/data/chargeNumber;chargeNumber;Quantidade de parcelas.;Número;;Opcional;;;0;1;" O campo deve ser preenchido quando houverem parcelas relacionadas a transação.
+";Não permitido;number;12
 /data/brazilianAmount;brazilianAmount;Valor da transação expresso em valor monetário com 4 casas decimais, em moeda corrente do Brasil;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;
 /data/brazilianAmount/amount;amount;Valor relacionado ao objeto.;Texto;20;Obrigatório;^\d{1,15}\.\d{2,4}$;;1;1;"";Não permitido;string;100000.0400
 /data/brazilianAmount/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL
@@ -57,4 +58,4 @@ Para recebedora: Ignorar o campo preenchido conforme esse cenário.
 /data/amount/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL
 /data/transactionDate;transactionDate;Data original da transação;Data;20;Obrigatório;^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$;;1;1;"";Não permitido;string;2021-05-21
 /data/billPostDate;billPostDate;Data em que a transação foi inserida na fatura;Data;20;Obrigatório;^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$;;1;1;"";Não permitido;string;2021-05-21
-/data/payeeMCC;payeeMCC;O MCC ou o código da categoria do estabelecimento comercial. Os MCCs são agrupados segundo suas similaridades. O MCC é usado para classificar o negócio pelo tipo fornecido de bens ou serviços. Os MCCs são atribuídos por tipo de comerciante (por exemplo, um para hotéis, um para lojas de materiais de escritório, etc.) ou por nome de comerciante (por exemplo, 3000 para a United Airlines).;Número;;Obrigatório;;;1;1;"";Não permitido;number;5137
+/data/payeeMCC;payeeMCC;O MCC ou o código da categoria do estabelecimento comercial. Os MCCs são agrupados segundo suas similaridades. O MCC é usado para classificar o negócio pelo tipo fornecido de bens ou serviços. Os MCCs são atribuídos por tipo de comerciante (por exemplo, um para hotéis, um para lojas de materiais de escritório, etc.) ou por nome de comerciante (por exemplo, 3000 para a United Airlines).;Número;;Opcional;;;0;1;"";Não permitido;number;5137

--- a/swagger-apis/credit-cards/2.0.0-RC1.0.yml
+++ b/swagger-apis/credit-cards/2.0.0-RC1.0.yml
@@ -611,8 +611,6 @@ components:
         - consolidationType
         - identificationNumber
         - isLimitFlexible
-        - limitAmountCurrency
-        - limitAmount
         - usedAmountCurrency
         - usedAmount
         - availableAmountCurrency
@@ -656,12 +654,15 @@ components:
           example: BRL
           description: |
             Moeda referente ao limite informado, segundo modelo ISO-4217. p.ex. 'BRL.'
-            Todos os limite informados estão representados com a moeda vigente do do Brasil.
+            Todos os limite informados estão representados com a moeda vigente do do Brasil.   
+            [Restrição] O campo é opcional caso isLimitFlexible for igual a false.
         limitAmount:
           type: string
           format: double
           pattern: '^-?\d{1,15}\.\d{2,4}$'
-          description: Valor total do limite informado Expresso em valor monetário com 4 casas decimais.
+          description: |
+            Valor total do limite informado Expresso em valor monetário com 4 casas decimais.   
+            [Restrição] O campo é opcional caso isLimitFlexible for igual a false.
           maxLength: 21
           example: '100000.0001'
         usedAmountCurrency:
@@ -751,12 +752,10 @@ components:
         - feeType
         - otherCreditsType
         - chargeIdentificator
-        - chargeNumber
         - brazilianAmount
         - amount
         - transactionDate
         - billPostDate
-        - payeeMCC
       properties:
         transactionId:
           type: string
@@ -820,9 +819,11 @@ components:
         chargeNumber:
           type: number
           format: integer
-          maximum: 2147483647
-          example: 3
-          description: Quantidade de parcelas
+          maximum: 999
+          example: 12
+          description: |
+            Quantidade de parcelas.   
+            [Restrição] O campo deve ser preenchido quando houverem parcelas relacionadas a transação.
         brazilianAmount:
           $ref: '#/components/schemas/CreditCardAccountsTransactionBrazilianAmount'
         amount:

--- a/swagger-components/schemas/credit_cards_apis/CreditCardAccountsLimitsData.yaml
+++ b/swagger-components/schemas/credit_cards_apis/CreditCardAccountsLimitsData.yaml
@@ -5,8 +5,6 @@ required:
   - consolidationType
   - identificationNumber
   - isLimitFlexible
-  - limitAmountCurrency
-  - limitAmount
   - usedAmountCurrency
   - usedAmount
   - availableAmountCurrency
@@ -42,12 +40,15 @@ properties:
     example: BRL
     description: |
       Moeda referente ao limite informado, segundo modelo ISO-4217. p.ex. 'BRL.'
-      Todos os limite informados estão representados com a moeda vigente do do Brasil.
+      Todos os limite informados estão representados com a moeda vigente do do Brasil.   
+      [Restrição] O campo é opcional caso isLimitFlexible for igual a false.
   limitAmount:
     type: string
     format: double
     pattern: '^-?\d{1,15}\.\d{2,4}$'
-    description: Valor total do limite informado Expresso em valor monetário com 4 casas decimais.
+    description: |
+      Valor total do limite informado Expresso em valor monetário com 4 casas decimais.   
+      [Restrição] O campo é opcional caso isLimitFlexible for igual a false.
     maxLength: 21
     example: '100000.0001'
   usedAmountCurrency:

--- a/swagger-components/schemas/credit_cards_apis/CreditCardAccountsTransaction.yaml
+++ b/swagger-components/schemas/credit_cards_apis/CreditCardAccountsTransaction.yaml
@@ -10,12 +10,10 @@ required:
   - feeType
   - otherCreditsType
   - chargeIdentificator
-  - chargeNumber
   - brazilianAmount
   - amount
   - transactionDate
   - billPostDate
-  - payeeMCC
 properties:
   transactionId:
     type: string
@@ -79,9 +77,11 @@ properties:
   chargeNumber:
     type: number
     format: integer
-    maximum: 2147483647
-    example: 3
-    description: Quantidade de parcelas
+    maximum: 999
+    example: 12
+    description: |
+     Quantidade de parcelas.   
+     [Restrição] O campo deve ser preenchido quando houverem parcelas relacionadas a transação.
   brazilianAmount:
     $ref: ./CreditCardAccountsTransactionBrazilianAmount.yaml
   amount:


### PR DESCRIPTION
Credit-cards | accounts/{creditCardAccountId}/limits | limitAmountCurrency - | Alterar obrigatoriedade para opcional, Acrescentar na descrição: [Restrição]: O campo opcional caso isLimitFlexible for igual a false.
-- | -- | -- | --
Credit-cards | accounts/{creditCardAccountId}/limits | limitAmount - | Alterar obrigatoriedade para opcional, Acrescentar na descrição: [Restrição]: O campo opcional caso isLimitFlexible for igual a false.
Credit-cards | accounts/{creditCardAccountId}/transactions | chargeNumber - | Alterar maximum para 999, Alterar obrigatoriedade para opcional, Alterar examplo para 12, Acrescentar na descrição: [Restrição]: O campo deve ser preenchido quando houverem parcelas relacionadas a transação.
Credit-cards | accounts/{creditCardAccountId}/transactions | payeeMCC - | Alterar obrigatoriedade para opcional

