### PR TITLE
fix(Dados Cadastrais): ORB-1410 - Ajustar campos de acordo homologação

### DIFF
--- a/dictionary/customersGetBusinessFinancialRelations_v2.csv
+++ b/dictionary/customersGetBusinessFinancialRelations_v2.csv
@@ -14,20 +14,19 @@ OPERACOES_CAMBIO
 CONTA_SALARIO 
 CREDENCIAMENTO 
 OUTROS";1;12;"";Não permitido;array;SEGURO
-/data/procurators;procurators;Lista dos representantes. De preenchimento obrigatório se houver representante.;Lista;;Obrigatório;;;1;N;"";Não permitido;array;
+/data/procurators;procurators;Lista dos representantes. De preenchimento obrigatório se houver representante.;Lista;;Obrigatório;;;0;N;"";Não permitido;array;
 /data/procurators/type;type;"Tipo de representante.
 Representante legal - Nome Civil completo da Pessoa Natural que represente uma entidade ou uma empresa e é nomeado em seu ato constitutivo, ou seja, no contrato social ou estatuto social.
 Procurador - é qualquer pessoa que represente a Pessoa Natural em algum negócio, mediante autorização escrita do mesmo.";Texto;;Obrigatório;;"REPRESENTANTE_LEGAL 
-PROCURADOR 
-NAO_POSSUI";1;1;"";Não permitido;string;PROCURADOR
+PROCURADOR";1;1;"";Não permitido;string;PROCURADOR
 /data/procurators/cnpjCpfNumber;cnpjCpfNumber;Identificação do Representante Legal ou Procurador. Número do cadastro nas Receita Federal  (Preencher com CPF ou CNPJ sem formatação);Texto;14;Obrigatório;^\d{11}$|^\d{14}$;;1;1;"";Não permitido;string;73677831148
 /data/procurators/civilName;civilName;Nome civil completo ou Razão Social;Texto;70;Obrigatório;[\w\W\s]*;;1;1;"";Não permitido;string;Elza Milena Stefany Teixeira
 /data/procurators/socialName;socialName;"Nome social da pessoa natural, se houver. Aquele pelo qual travestis e transexuais se reconhecem, 
-bem como são identificados por sua comunidade e em seu meio social, conforme Decreto Local.";Texto;70;Obrigatório;[\w\W\s]*;;1;1;" Preenchimento obrigatório quando o sócio for uma pessoa natural.
-";Não permitido;string;Stefany Teixeirass
+bem como são identificados por sua comunidade e em seu meio social, conforme Decreto Local.";Texto;70;Opcional;[\w\W\s]*;;0;1;"";Não permitido;string;Stefany Teixeirass
 /data/accounts;accounts;Lista de contas depósito à vista, poupança e pagamento pré-pagas mantidas pelo cliente na instituição transmissora.;Lista;;Obrigatório;;;1;N;"";Não permitido;array;
 /data/accounts/compeCode;compeCode;Código identificador atribuído pelo Banco Central do Brasil às instituições participantes do STR (Sistema de Transferência de reservas).O Compe (Sistema de Compensação de Cheques e Outros Papéis) é um sistema que identifica e processa as compensações bancárias. Ele é representado por um código de três dígitos que serve como identificador de bancos, sendo assim, cada instituição bancária possui um número exclusivo;Texto;3;Obrigatório;^\d{3}$;;1;1;"";Não permitido;string;001
-/data/accounts/branchCode;branchCode;Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória);Texto;4;Obrigatório;^\d{4}$;;1;1;"";Não permitido;string;6272
+/data/accounts/branchCode;branchCode;Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória);Texto;4;Opcional;^\d{4}$;;0;1;" Obrigatoriamente deve ser preenchido quando o campo ""type"" for diferente de conta pré paga.
+";Não permitido;string;6272
 /data/accounts/number;number;Número da conta;Texto;20;Obrigatório;^\d{8,20}$;;1;1;"";Não permitido;string;24550245
 /data/accounts/checkDigit;checkDigit;Dígito da conta;Texto;1;Obrigatório;[\w\W\s]*;;1;1;"";Não permitido;string;4
 /data/accounts/type;type;"Tipos de contas. Modalidades tradicionais previstas pela Resolução 4.753, não contemplando contas vinculadas, conta de domiciliados no exterior, contas em moedas estrangeiras e conta correspondente moeda eletrônica. Vide Enum

--- a/swagger-apis/customers/2.0.0-RC1.0.yml
+++ b/swagger-apis/customers/2.0.0-RC1.0.yml
@@ -331,7 +331,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BusinessProcurator'
-          minItems: 1
+          minItems: 0
           description: Lista dos representantes. De preenchimento obrigatório se houver representante.
         accounts:
           type: array
@@ -433,14 +433,12 @@ components:
         - type
         - cnpjCpfNumber
         - civilName
-        - socialName
       properties:
         type:
           type: string
           enum:
             - REPRESENTANTE_LEGAL
             - PROCURADOR
-            - NAO_POSSUI
           description: |
             Tipo de representante.
             Representante legal - Nome Civil completo da Pessoa Natural que represente uma entidade ou uma empresa e é nomeado em seu ato constitutivo, ou seja, no contrato social ou estatuto social.
@@ -466,7 +464,6 @@ components:
           description: |
             Nome social da pessoa natural, se houver. Aquele pelo qual travestis e transexuais se reconhecem, 
             bem como são identificados por sua comunidade e em seu meio social, conforme Decreto Local.
-            [Restrição] Preenchimento obrigatório quando o sócio for uma pessoa natural.
       additionalProperties: false
     BusinessQualificationData:
       type: object
@@ -820,7 +817,6 @@ components:
       type: object
       required:
         - compeCode
-        - branchCode
         - number
         - checkDigit
         - type
@@ -836,7 +832,8 @@ components:
           maxLength: 4
           pattern: '^\d{4}$'
           description: |
-            Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória)
+            Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória)   
+            [Restrição] Obrigatoriamente deve ser preenchido quando o campo "type" for diferente de conta pré paga.
           example: '6272'
         number:
           type: string

--- a/swagger-components/schemas/customers_apis/BusinessAccount.yaml
+++ b/swagger-components/schemas/customers_apis/BusinessAccount.yaml
@@ -1,7 +1,6 @@
 type: object
 required:
   - compeCode
-  - branchCode
   - number
   - checkDigit
   - type
@@ -17,7 +16,8 @@ properties:
     maxLength: 4
     pattern: ^\d{4}$
     description: |
-      Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória)
+      Código da Agência detentora da conta. (Agência é a dependência destinada ao atendimento aos clientes, ao público em geral e aos associados de cooperativas de crédito, no exercício de atividades da instituição, não podendo ser móvel ou transitória)   
+      [Restrição] Obrigatoriamente deve ser preenchido quando o campo "type" for diferente de conta pré paga.
     example: '6272'
   number:
     type: string

--- a/swagger-components/schemas/customers_apis/BusinessFinancialRelationData.yaml
+++ b/swagger-components/schemas/customers_apis/BusinessFinancialRelationData.yaml
@@ -31,7 +31,7 @@ properties:
     type: array
     items:
       $ref: ./BusinessProcurator.yaml
-    minItems: 1
+    minItems: 0
     description: Lista dos representantes. De preenchimento obrigatório se houver representante.
   accounts:
     type: array

--- a/swagger-components/schemas/customers_apis/BusinessProcurator.yaml
+++ b/swagger-components/schemas/customers_apis/BusinessProcurator.yaml
@@ -3,7 +3,6 @@ required:
   - type
   - cnpjCpfNumber
   - civilName
-  - socialName
 properties:
   type:
     $ref: ../enum/EnumProcuratorsTypeBusiness.yaml
@@ -27,5 +26,4 @@ properties:
     description: |
       Nome social da pessoa natural, se houver. Aquele pelo qual travestis e transexuais se reconhecem, 
       bem como são identificados por sua comunidade e em seu meio social, conforme Decreto Local.
-      [Restrição] Preenchimento obrigatório quando o sócio for uma pessoa natural.
 additionalProperties: false

--- a/swagger-components/schemas/enum/EnumProcuratorsTypeBusiness.yaml
+++ b/swagger-components/schemas/enum/EnumProcuratorsTypeBusiness.yaml
@@ -2,7 +2,6 @@ type: string
 enum:
   - REPRESENTANTE_LEGAL
   - PROCURADOR
-  - NAO_POSSUI
 description: |
   Tipo de representante.
   Representante legal - Nome Civil completo da Pessoa Natural que represente uma entidade ou uma empresa e é nomeado em seu ato constitutivo, ou seja, no contrato social ou estatuto social.


### PR DESCRIPTION
campo|Alteração
-- | --
procurators | Alterar minItens do objeto procurators para 0, Retirar a opção NAO_POSSUI do enum type, Alterar socialName para opcional e remover restrição [Restrição] Preenchimento obrigatório quando o sócio for uma pessoa natural.
accounts/branchCode | Tornar campo condicional incluindo a restrição [Restrição] Obrigatóriamente deve ser preenchido quando o campo "type" for diferente de conta pré paga.

